### PR TITLE
Skip Discussions auto-reply to select users

### DIFF
--- a/.github/workflows/discussion-reply.yml
+++ b/.github/workflows/discussion-reply.yml
@@ -12,18 +12,21 @@ jobs:
         with:
           github-token: ${{ secrets.TEAM_DEEPGRAM_BOT_PAT }}
           script: |
-            const mutation = `mutation AddComment($input: AddDiscussionCommentInput!) {
-              addDiscussionComment(input: $input){
-                comment {
-                  id
-                  body
+            dg_users = ['U_kgDOCOcF3A']
+            if (!dg_users.includes(context.payload.sender.node_id)) {
+              const mutation = `mutation AddComment($input: AddDiscussionCommentInput!) {
+                addDiscussionComment(input: $input){
+                  comment {
+                    id
+                    body
+                  }
+                }
+              }`;
+              const variables = {
+                input: {
+                  body: 'Thanks for asking your question about Deepgram! If you didn\'t already include it in your post, please be sure to add as much detail as possible so we can assist you efficiently, such as:\n- The `request_id` if you have a question about your requests or transcription responses.\n- The features you used or the full `api.deepgram.com` URL you sent your request to, including parameters.\n- Any code snippets you can share.',
+                  discussionId: context.payload.discussion.node_id,
                 }
               }
-            }`;
-            const variables = {
-              input: {
-                body: 'Thanks for asking your question about Deepgram! If you didn\'t already include it in your post, please be sure to add as much detail as possible so we can assist you efficiently, such as:\n- The `request_id` if you have a question about your requests or transcription responses.\n- The features you used or the full `api.deepgram.com` URL you sent your request to, including parameters.\n- Any code snippets you can share.',
-                discussionId: context.payload.discussion.node_id,
-              }
+              const result = await github.graphql(mutation, variables)
             }
-            const result = await github.graphql(mutation, variables)


### PR DESCRIPTION
Adds a list of user IDs (currently containing only the "team-deepgram" user ID), where posts from those users will not trigger the auto-reply message.

The initial purpose of this is to avoid replies to Discord-automated posts.

To get any GitHub user's ID, you can use the [GitHub GraphQL Explorer](https://docs.github.com/en/graphql/overview/explorer) with query:
```
query {
  user(login: "<username>") {
    id
  }
}
```